### PR TITLE
Update exp5.l

### DIFF
--- a/compiler-design/shortened-pgms/exp5.l
+++ b/compiler-design/shortened-pgms/exp5.l
@@ -7,10 +7,10 @@ identifier [a-zA-Z][a-zA-Z0-9]*
 int|float|char|double|while|for|if|break|continue|void|return|else {printf("\n%s is a keyword", yytext);}
 
 {identifier}\( {printf("\nFunction %s", yytext);}
-"{" {printf("\nBLOCK BEGINS");}
+"{" {printf("BLOCK BEGINS");}
 "}" {printf("BLOCK ENDS ");}
 
-{identifier}(\[[0-9]*\])? {printf("\n%s is an IDENTIFIER", yytext);}
+{identifier} {printf("\n%s is an IDENTIFIER", yytext);}
 \".*\" {printf("\n%s is a STRING", yytext);}
 [0-9]+ {printf("\n%s is a CONSTANT", yytext);}
 


### PR DESCRIPTION
removed `(\[[0-9]*\])?` why add this when we have already defined the same as `identifier [a-zA-Z][a-zA-Z0-9]* ` 